### PR TITLE
support RP2040 (core earlephilhower)

### DIFF
--- a/Simple_Wire.cpp
+++ b/Simple_Wire.cpp
@@ -60,6 +60,7 @@ void Simple_Wire::begin(int sdaPin, int sclPin) {
 #elif defined(ARDUINO_ARCH_RP2040)
     Wire.setSCL(sclPin);
     Wire.setSDA(sdaPin);
+    Wire.begin();
     Wire.setClock(400000); // 400kHz I2C clock.
 #else  
     Wire.begin();

--- a/Simple_Wire.cpp
+++ b/Simple_Wire.cpp
@@ -55,8 +55,12 @@ void Simple_Wire::begin(int sdaPin, int sclPin) {
     Wire.begin();
     Wire.setClock(400000); // 400kHz I2C clock.
     Wire.setWireTimeout(3000, true); //timeout value in uSec
-#elif defined(ESP8266) || defined(ESP32) || defined(ARDUINO_ARCH_RP2040)
+#elif defined(ESP8266) || defined(ESP32) 
     Wire.begin(sdaPin,sclPin,(uint32_t)400000); // 400kHz I2C clock.
+#elif defined(ARDUINO_ARCH_RP2040)
+    Wire.setSCL(sclPin);
+    Wire.setSDA(sdaPin);
+    Wire.setClock(400000); // 400kHz I2C clock.
 #else  
     Wire.begin();
     Wire.setClock(400000); // 400kHz I2C clock.


### PR DESCRIPTION
Added alternative for RP2040 to set PINs the way this platform/core has in Wire.h

For more about the RP2040 core implementation, see here: https://github.com/earlephilhower/arduino-pico